### PR TITLE
feat: adds option to pass file regex pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/aind_behavior_video_transformation/etl.py
+++ b/src/aind_behavior_video_transformation/etl.py
@@ -52,6 +52,10 @@ class BehaviorVideoJobSettings(BasicJobSettings):
     ffmpeg_thread_cnt: int = Field(
         default=0, description="Number of threads per ffmpeg compression job."
     )
+    file_filter: Optional[str] = Field(
+        default=None,
+        description=("If set, filter file paths based on regex pattern."),
+    )
 
 
 class BehaviorVideoJob(GenericEtl[BehaviorVideoJobSettings]):
@@ -150,8 +154,13 @@ class BehaviorVideoJob(GenericEtl[BehaviorVideoJobSettings]):
         ffmpeg_arg_set = (
             self.job_settings.compression_requested.determine_ffmpeg_arg_set()
         )
+        file_filter = self.job_settings.file_filter
         convert_video_args = transform_directory(
-            job_in_dir_path, job_out_dir_path, ffmpeg_arg_set, overrides
+            job_in_dir_path,
+            job_out_dir_path,
+            ffmpeg_arg_set,
+            overrides,
+            file_filter,
         )
         self._run_compression(convert_video_args)
 

--- a/src/aind_behavior_video_transformation/etl.py
+++ b/src/aind_behavior_video_transformation/etl.py
@@ -54,7 +54,7 @@ class BehaviorVideoJobSettings(BasicJobSettings):
     )
     file_filter: Optional[str] = Field(
         default=None,
-        description=("If set, filter file paths based on regex pattern."),
+        description="If set, filter file paths based on regex pattern.",
     )
 
 

--- a/src/aind_behavior_video_transformation/filesystem.py
+++ b/src/aind_behavior_video_transformation/filesystem.py
@@ -1,8 +1,10 @@
 """Module for handling file discovery to transform videos."""
 
+import re
 from os import symlink, walk
 from os.path import relpath
 from pathlib import Path
+from typing import Optional
 
 
 def likely_video_file(file: Path) -> bool:
@@ -80,7 +82,11 @@ def build_overrides_dict(video_comp_pairs, job_in_dir_path):
 
 
 def transform_directory(
-    input_dir: Path, output_dir: Path, arg_set, overrides=dict()
+    input_dir: Path,
+    output_dir: Path,
+    arg_set,
+    overrides=dict(),
+    file_filter_pattern: Optional[str] = None,
 ) -> list[tuple[Path, Path, tuple[str, str] | None]]:
     """
     Transforms all video files in a directory and its subdirectories,
@@ -100,6 +106,8 @@ def transform_directory(
         A dictionary containing overrides for specific directories or files.
         Keys are Paths and values are argument sets. Default is an empty
         dictionary.
+    file_filter_pattern : str | None
+        If set, will filter file names based on this pattern. Default is None.
 
     Returns
     -------
@@ -117,6 +125,10 @@ def transform_directory(
 
         for file_name in files:
             file_path = Path(root) / file_name
+            if file_filter_pattern and not re.match(
+                file_filter_pattern, file_name
+            ):
+                continue
             if likely_video_file(file_path):
                 # If the parent directory has an override, use that
                 this_arg_set = overrides.get(root_path, arg_set)

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,183 @@
+"""Tests methods in filesystem module."""
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+from aind_behavior_video_transformation.filesystem import transform_directory
+
+
+class TestModule(unittest.TestCase):
+    """Tests methods in module"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up class with some mocked os.walk outputs."""
+
+        cls.example_ffmpeg_args = (
+            "",
+            '-vf "scale=out_color_matrix=bt709:out_range=full:sws_dither=none,'
+            "format=yuv420p10le,colorspace=ispace=bt709:all=bt709:dither=none,"
+            'scale=out_range=tv:sws_dither=none,format=yuv420p" -c:v libx264 '
+            "-preset veryslow -crf 18 -pix_fmt yuv420p -metadata "
+            'author="Allen Institute for Neural Dynamics" '
+            "-movflags +faststart+write_colr",
+        )
+        cls.example_src = Path("behavior-videos")
+        cls.example_directory_walk_vr_foraging = [
+            (
+                "behavior-videos",
+                ["FaceCamera", "FrontCamera", "SideCamera"],
+                [],
+            ),
+            (
+                str(Path("behavior-videos") / "FaceCamera"),
+                [],
+                ["metadata.csv", "video.mp4"],
+            ),
+            (
+                str(Path("behavior-videos") / "FrontCamera"),
+                [],
+                ["metadata.csv", "video.mp4"],
+            ),
+            (
+                str(Path("behavior-videos") / "SideCamera"),
+                [],
+                ["metadata.csv", "video.mp4"],
+            ),
+        ]
+        cls.example_directory_walk_chronic_ephys = [
+            ("behavior-videos", ["TopCamera"], []),
+            (
+                str(Path("behavior-videos") / "TopCamera"),
+                [],
+                [
+                    "TopCamera_2025-05-13T19-00-00.csv",
+                    "TopCamera_2025-05-13T19-00-00.mp4",
+                    "TopCamera_2025-05-13T20-00-00.csv",
+                    "TopCamera_2025-05-13T20-00-00.mp4",
+                ],
+            ),
+        ]
+
+    @patch("aind_behavior_video_transformation.filesystem.walk")
+    @patch("pathlib.Path.mkdir")
+    @patch("aind_behavior_video_transformation.filesystem.symlink")
+    def test_transform_directory(
+        self,
+        mock_symlink: MagicMock,
+        mock_mkdir: MagicMock,
+        mock_walk: MagicMock,
+    ):
+        """Tests transform_directory"""
+
+        mock_walk.return_value = self.example_directory_walk_vr_foraging
+        job_in_dir_path = self.example_src
+        overrides = dict()
+        ffmpeg_arg_set = self.example_ffmpeg_args
+        file_filter = None
+        job_out_dir_path = Path("output_directory")
+        expected_convert_video_args = [
+            (
+                Path("behavior-videos") / "FaceCamera" / "video.mp4",
+                Path("output_directory") / "FaceCamera",
+                self.example_ffmpeg_args,
+            ),
+            (
+                Path("behavior-videos") / "FrontCamera" / "video.mp4",
+                Path("output_directory") / "FrontCamera",
+                self.example_ffmpeg_args,
+            ),
+            (
+                Path("behavior-videos") / "SideCamera" / "video.mp4",
+                Path("output_directory") / "SideCamera",
+                self.example_ffmpeg_args,
+            ),
+        ]
+        actual_convert_video_args = transform_directory(
+            job_in_dir_path,
+            job_out_dir_path,
+            ffmpeg_arg_set,
+            overrides,
+            file_filter,
+        )
+        self.assertEqual(
+            expected_convert_video_args, actual_convert_video_args
+        )
+        mock_symlink.assert_has_calls(
+            [
+                call(
+                    Path("behavior-videos") / "FaceCamera" / "metadata.csv",
+                    Path("output_directory") / "FaceCamera" / "metadata.csv",
+                ),
+                call(
+                    Path("behavior-videos") / "FrontCamera" / "metadata.csv",
+                    Path("output_directory") / "FrontCamera" / "metadata.csv",
+                ),
+                call(
+                    Path("behavior-videos") / "SideCamera" / "metadata.csv",
+                    Path("output_directory") / "SideCamera" / "metadata.csv",
+                ),
+            ]
+        )
+        mock_mkdir.assert_has_calls(
+            [
+                call(parents=True, exist_ok=True),
+                call(parents=True, exist_ok=True),
+                call(parents=True, exist_ok=True),
+            ]
+        )
+
+    @patch("aind_behavior_video_transformation.filesystem.walk")
+    @patch("pathlib.Path.mkdir")
+    @patch("aind_behavior_video_transformation.filesystem.symlink")
+    def test_transform_directory_with_file_filter(
+        self,
+        mock_symlink: MagicMock,
+        mock_mkdir: MagicMock,
+        mock_walk: MagicMock,
+    ):
+        """Tests transform_directory with filter_filter set"""
+
+        mock_walk.return_value = self.example_directory_walk_chronic_ephys
+        job_in_dir_path = self.example_src
+        overrides = dict()
+        ffmpeg_arg_set = self.example_ffmpeg_args
+        file_filter = ".*2025-05-13T20-00-00.*"
+        job_out_dir_path = Path("output_directory")
+        expected_convert_video_args = [
+            (
+                Path("behavior-videos")
+                / "TopCamera"
+                / "TopCamera_2025-05-13T20-00-00.mp4",
+                Path("output_directory") / "TopCamera",
+                self.example_ffmpeg_args,
+            )
+        ]
+        actual_convert_video_args = transform_directory(
+            job_in_dir_path,
+            job_out_dir_path,
+            ffmpeg_arg_set,
+            overrides,
+            file_filter,
+        )
+        self.assertEqual(
+            expected_convert_video_args, actual_convert_video_args
+        )
+        mock_symlink.assert_has_calls(
+            [
+                call(
+                    Path("behavior-videos")
+                    / "TopCamera"
+                    / "TopCamera_2025-05-13T20-00-00.csv",
+                    Path("output_directory")
+                    / "TopCamera"
+                    / "TopCamera_2025-05-13T20-00-00.csv",
+                )
+            ]
+        )
+        mock_mkdir.assert_has_calls([call(parents=True, exist_ok=True)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #29 

- Removes `setuptools-scm` from build-system, which has been causing issues in github actions workflows
- Adds parameter to allow use to better control which files in a directory will be processed. This is needed for the chronic ephys data collection where one hour chunks are added to a directory, and we want to process one hour at a time.
- Adds test to verify filter works